### PR TITLE
Parameterize Performance Insights, make iops parameter nullable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ module "db" {
   tags                                  = merge(var.tags, module.standard_tags.tags)
   username                              = var.username
   vpc_security_group_ids                = [join("", aws_security_group.db.*.id)]
-  performance_insights_enabled          = true
+  performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = 7
   monitoring_role_arn                   = join("", aws_iam_role.rds_enhanced_monitoring.*.arn)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "storage_type" {
 variable "iops" {
   description = "The amount of provisioned IOPS. Setting implies a storage_type of io1."
   type        = number
-  default     = 500
+  default     = null
 }
 
 variable "kms_key_arn" {
@@ -165,6 +165,12 @@ variable "backup_retention_period" {
   description = "How long to keep backups for (in days)"
   type        = number
   default     = 7
+}
+
+variable "performance_insights_enabled" {
+  description = "Switch to enable or disable Performance Insights for the DB instance. Not supported for all instance types."
+  type        = bool
+  default     = true
 }
 
 variable "preferred_backup_window" {


### PR DESCRIPTION
Parameterizing performance insights, as it's not supported on smaller (t size) instances. 
Updated performance insights variable description to be clear about not being supported on all instance types.
Modified iops parameter to be nullable, for ease of implementing gp3. Error is [here](https://bitbucket.org/truemark/terraform-blue-database/pipelines/results/271/steps/%7Be118f7dc-7213-4cd6-bab1-e4895a7f4e70%7D) and [here](https://bitbucket.org/truemark/terraform-blue-database/pipelines/results/273/steps/%7B128cfd72-772a-41db-bc27-affa7a576663%7D)

```
│ Error: creating RDS DB Instance (common-mysql): InvalidParameterCombination: You can't specify IOPS or storage throughput for engine mysql and a storage size less than 400.
│ 	status code: 400, request id: 37ff74fd-e8f1-4498-b4b8-6b6270469963
```


and [here](https://bitbucket.org/truemark/terraform-blue-database/pipelines/results/272/steps/%7Bae3f1c70-4135-43e5-9524-7795f798ce73%7D)

```
│ Error: creating RDS DB Instance (common-mysql): InvalidParameterCombination: Invalid iops value for engine name mysql and storage type gp3: 500
│ 	status code: 400, request id: da208a25-6562-4642-a581-9f45ffba3e0a
```